### PR TITLE
Enable tooltip settings for Sankey chart

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -235,5 +235,15 @@
     },
     "supportsKeyboardFocus": true,
     "supportsSynchronizingFilterState": true,
-    "privileges": []
+    "privileges": [],
+    "tooltips": {
+        "supportedTypes": {
+            "default": true,
+            "canvas": true
+        },
+        "supportEnhancedTooltips": true,
+        "roles": [
+            "tooltips"
+        ]
+    }
 }


### PR DESCRIPTION
This change enables tooltip settings for the chart in PowerBI:
- Turn on/off tooltip
- Set report page as a tooltip
![image](https://github.com/microsoft/powerbi-visuals-sankey/assets/8245429/517704db-b1aa-49c5-b5e5-b5bef9f1e535)
